### PR TITLE
lsコマンドを作る2 @ FBC

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,20 +2,19 @@
 # frozen_string_literal: true
 
 require_relative 'ls_methods'
+require 'optparse'
 
 def main
-  args = { 'option' => nil, 'path' => '.' }
+  option = {}
+  opt = OptionParser.new
 
-  ARGV.each do |arg|
-    if arg.start_with?('-')
-      args['option'] = arg[1..]
-    else
-      args['path'] = arg
-    end
-  end
+  # optionをコンテナに格納
+  opt.on('-a') { |v| option[:a] = v }
+  opt.parse!(ARGV)
 
-  contents = get_files(args['path'])
-  ls_with_options(contents, args['option'])
+  contents = get_files(ARGV[0])
+  convert_with_option!(contents, option)
+  show_ls(contents)
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,10 +9,11 @@ def main
 
   opt.on('-a') { |v| option[:a] = v }
   opt.parse!(ARGV)
+  # ARGV[0]にpathの入力値が渡される。
   path = ARGV[0].nil? ? '.' : ARGV[0]
   contents = get_files(path)
   converted_contents = convert_with_option(contents, option)
-  show_ls(converted_contents)
+  show(converted_contents)
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,11 +9,11 @@ def main
 
   opt.on('-a') { |v| option[:a] = v }
   opt.parse!(ARGV)
-  # ARGV[0]にpathの入力値が渡される。
+  # ARGV[0]にpathの入力値が渡される。ファイル名を渡すことは出来ない。
   path = ARGV[0].nil? ? '.' : ARGV[0]
   contents = get_files(path)
-  converted_contents = convert_with_option(contents, option)
-  show(converted_contents)
+  filtered_contents = filter_with_option(contents, option)
+  show(filtered_contents)
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require_relative 'ls_methods'
@@ -10,10 +9,10 @@ def main
 
   opt.on('-a') { |v| option[:a] = v }
   opt.parse!(ARGV)
-
-  contents = get_files(ARGV[0])
-  convert_with_option!(contents, option)
-  show_ls(contents)
+  path = ARGV[0].nil? ? '.' : ARGV[0]
+  contents = get_files(path)
+  converted_contents = convert_with_option(contents, option)
+  show_ls(converted_contents)
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,7 +8,6 @@ def main
   option = {}
   opt = OptionParser.new
 
-  # optionをコンテナに格納
   opt.on('-a') { |v| option[:a] = v }
   opt.parse!(ARGV)
 

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -2,6 +2,8 @@
 
 require 'etc'
 
+COLUMN_NUMBER = 3
+
 def get_files(path)
   Dir.entries(path).sort
 end
@@ -16,11 +18,10 @@ end
 
 def show(contents)
   maximum_length = contents.max_by(&:length).length + 3
-  height = contents.length.ceildiv(3)
-  # 行のナンバリング
+  height = contents.length.ceildiv(COLUMN_NUMBER)
+
   (0...height).each do |h_num|
-    # 列のナンバリング　今回は最大３列までなので最大３つまで表示したら次の行に折り返す。
-    3.times do |w_num|
+    COLUMN_NUMBER.times do |w_num|
       contents_index = h_num + (height * w_num)
       print contents[contents_index].ljust(maximum_length) if !contents[contents_index].nil?
     end

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -11,7 +11,7 @@ def convert_with_option!(contents, option)
   else
     case option
     when option[:a]
-      contents
+      contents # 引数のcontentsはオプション指定時に隠しファイルを含むものが渡されるのでそのまま返す。
     end
   end
 end

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -14,7 +14,7 @@ def convert_with_option(contents, option)
   contents
 end
 
-def show_ls(contents)
+def show(contents)
   maximum_length = contents.max_by(&:length).length + 3
   height = contents.length.ceildiv(3)
   # 行のナンバリング

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
+require 'etc'
+
 def get_files(path)
-  path ||= '.'
   Dir.entries(path).sort
 end
 
-def convert_with_option!(contents, option)
-  if option.empty?
-    contents.reject! { |content| content.start_with?('.') } # hidden fileをcontentsから除外する。
-  elsif option[:a]
-    contents
+def convert_with_option(contents, option)
+  unless option[:a]
+    converted_contents = contents.reject { |content| content.start_with?('.') } # hidden fileをcontentsから除外する。
+    return converted_contents
   end
+  contents
 end
 
 def show_ls(contents)

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
 def get_files(path)
+  path ||= '.'
   Dir.entries(path).sort
 end
 
-def ls_with_options(contents, option)
-  if option.nil?
-    filtered_contents = contents.filter { |content| !content.start_with?('.') } # hidden fileをcontentsから除外する。
+def convert_with_option!(contents, option)
+  if option.empty?
+    contents.reject! { |content| content.start_with?('.') } # hidden fileをcontentsから除外する。
+  else
+    case option
+    when option[:a]
+      contents
+    end
   end
-  show_ls(filtered_contents)
 end
 
 def show_ls(contents)

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -8,11 +8,8 @@ end
 def convert_with_option!(contents, option)
   if option.empty?
     contents.reject! { |content| content.start_with?('.') } # hidden fileをcontentsから除外する。
-  else
-    case option
-    when option[:a]
-      contents # 引数のcontentsはオプション指定時に隠しファイルを含むものが渡されるのでそのまま返す。
-    end
+  elsif option[:a]
+    contents
   end
 end
 

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -17,7 +17,7 @@ def convert_with_option(contents, option)
 end
 
 def show(contents)
-  maximum_length = contents.max_by(&:length).length + 3
+  maximum_length = contents.max_by(&:length).length + 3 # 本家lsコマンドに寄せたスペース幅に調整
   height = contents.length.ceildiv(COLUMN_NUMBER)
 
   (0...height).each do |h_num|

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -8,11 +8,9 @@ def get_files(path)
   Dir.entries(path).sort
 end
 
-def convert_with_option(contents, option)
-  unless option[:a]
-    converted_contents = contents.reject { |content| content.start_with?('.') } # hidden fileをcontentsから除外する。
-    return converted_contents
-  end
+def filter_with_option(contents, option)
+  return contents.reject { |content| content.start_with?('.') } unless option[:a]
+
   contents
 end
 


### PR DESCRIPTION
### 使い方
```
ruby 04.ls/ls.rb [-a] [path] 
```
※デフォルト値でpathはカレントディレクトリを参照します。
### 実施内容
- -a オプションを追加したlsコマンドを作成。
### PRポイント
- 最後に実装する複数オプションの実装を見据えて、取得したファイルの変更操作を複数のオプション指定時に優先度が高いものから条件を指定して操作を行えるようにcase使ってlsオプションの条件分岐をしています。
- PRの出し方を変えたので改善点があれば教えて欲しいです！
### 実行結果
rubocop: 
```
rubocop 04.ls 
Inspecting 2 files
..

2 files inspected, no offenses detected
```

実行結果:
```
何も指定しない場合

shunhamm@PM-PM9NWYCWGV ruby-practices % ruby 04.ls/ls.rb                                                                                         
01.fizzbuzz         05.wc               99.wc_object        
02.calendar         06.bowling_object   README.md           
03.bowling          07.ls_object        practice.rb         
04.ls               98.rake        

-a オプション
    
shunhamm@PM-PM9NWYCWGV ruby-practices % ruby 04.ls/ls.rb -a
.                   02.calendar         98.rake             
..                  03.bowling          99.wc_object        
.git                04.ls               README.md           
.gitignore          05.wc               practice.rb         
.rubocop.yml        06.bowling_object   
01.fizzbuzz         07.ls_object   
```
