### PR TITLE
lsコマンド作成4@FBC

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,20 +2,22 @@
 # frozen_string_literal: true
 
 require_relative 'ls_methods'
+require 'optparse'
 
 def main
-  args = { 'option' => nil, 'path' => '.' }
+  option = {}
+  opt = OptionParser.new
 
-  ARGV.each do |arg|
-    if arg.start_with?('-')
-      args['option'] = arg[1..]
-    else
-      args['path'] = arg
-    end
+  opt.on('-l') { |v| option[:l] = v }
+  opt.parse!(ARGV)
+  path = ARGV[0].nil? ? '.' : ARGV[0]
+  contents = get_files(path)
+  converted_contents = convert_with_option!(contents, option, path)
+  # lオプションがあると表示が変わる
+  if option[:l]
+    converted_contents.each { |content| puts content }
+  else
+    show_ls(converted_contents)
   end
-
-  contents = get_files(args['path'])
-  ls_with_options(contents, args['option'])
 end
-
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -13,7 +13,7 @@ def main
   path = ARGV[0].nil? ? '.' : ARGV[0]
   contents = get_files(path)
   converted_contents = convert_with_option!(contents, option, path)
-  # lオプションがあると表示が変わる
+
   if option[:l]
     converted_contents.each { |content| puts content }
   else

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,7 +11,7 @@ def main
   opt.on('-l') { |v| option[:l] = v }
   opt.parse!(ARGV)
   path = ARGV[0].nil? ? '.' : ARGV[0]
-  files = get_files(path)
+  files = files(path)
   transformed_files = transform_files_for_long_format(files, option, path)
 
   if option[:l]

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,13 +11,13 @@ def main
   opt.on('-l') { |v| option[:l] = v }
   opt.parse!(ARGV)
   path = ARGV[0].nil? ? '.' : ARGV[0]
-  contents = get_files(path)
-  transformed_contents = transform_contents_for_long_format(contents, option, path)
+  files = get_files(path)
+  transformed_files = transform_files_for_long_format(files, option, path)
 
   if option[:l]
-    transformed_contents.each { |content| puts content }
+    transformed_files.each { |files| puts files }
   else
-    show_as_grid(transformed_contents)
+    show_as_grid(transformed_files)
   end
 end
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -12,12 +12,12 @@ def main
   opt.parse!(ARGV)
   path = ARGV[0].nil? ? '.' : ARGV[0]
   contents = get_files(path)
-  transformed_contents = transform_by_option(contents, option, path)
+  transformed_contents = transform_contents_for_long_format(contents, option, path)
 
   if option[:l]
     transformed_contents.each { |content| puts content }
   else
-    show(transformed_contents)
+    show_as_grid(transformed_contents)
   end
 end
 main

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -15,7 +15,7 @@ PERMISSION_MAP = {
   '0' => '---'
 }.freeze
 
-def get_files(path)
+def files(path)
   Dir.entries(path).sort
 end
 
@@ -23,7 +23,7 @@ def transform_files_for_long_format(files, option, path)
   filtered_files = files.reject { |file| file.start_with?('.') }
 
   if option[:l]
-    get_file_detail_array(path, filtered_files)
+    file_stats(path, filtered_files)
   else
     filtered_files
   end
@@ -42,7 +42,7 @@ def show_as_grid(files)
   end
 end
 
-def get_file_type(file_lstat)
+def file_type(file_lstat)
   if file_lstat.file?
     '-'
   elsif file_lstat.symlink?
@@ -58,8 +58,8 @@ def get_file_type(file_lstat)
   end
 end
 
-def get_file_detail_array(path, file_names)
-  file_detail_array = []
+def file_stats(path, file_names)
+  file_stats = []
   max_size_length = 0
 
   file_names.each do |file_name|
@@ -67,18 +67,18 @@ def get_file_detail_array(path, file_names)
     fs = File::Stat.new(outfile)
     size_length = fs.size.to_s.length
     max_size_length = size_length if size_length > max_size_length
-    file_type = get_file_type(File.lstat(outfile)) # File::Statは自動的にシンボリックリンクをたどっていき常にfalseを返すのでlstatを渡す。
+    file_type = file_type(File.lstat(outfile)) # File::Statは自動的にシンボリックリンクをたどっていき常にfalseを返すのでlstatを渡す。
     octal_mode = fs.mode.to_s(8).rjust(6, '0')
     mode = "#{PERMISSION_MAP[octal_mode[3]]}#{PERMISSION_MAP[octal_mode[4]]}#{PERMISSION_MAP[octal_mode[5]]}"
     time = fs.mtime.strftime('%m %d %H:%M ')
-    file_detail_array << [file_type + mode, fs.nlink.to_s.rjust(2), Etc.getpwuid(fs.uid).name, Etc.getgrgid(fs.gid).name, fs.size.to_s, time, file_name]
+    file_stats << [file_type + mode, fs.nlink.to_s.rjust(2), Etc.getpwuid(fs.uid).name, Etc.getgrgid(fs.gid).name, fs.size.to_s, time, file_name]
   end
 
   # 最大文字列長に合わせて整形
-  formatted_file_detail_array = []
-  file_detail_array.each do |s|
+  formatted_file_stats = []
+  file_stats.each do |s|
     s[4] = s[4].rjust(max_size_length + 1)
-    formatted_file_detail_array << s.join(' ')
+    formatted_file_stats << s.join(' ')
   end
-  formatted_file_detail_array
+  formatted_file_stats
 end

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -4,16 +4,6 @@ require 'etc'
 COLUMN_NUMBER = 3
 SPACE_NUMBER = 3
 
-FILE_MAP = {
-  '010' => 'p',
-  '020' => 'c',
-  '040' => 'd',
-  '060' => 'b',
-  '100' => '-',
-  '120' => '|',
-  '140' => 's'
-}.freeze
-
 PERMISSION_MAP = {
   '7' => 'rwx',
   '6' => 'rw-',
@@ -29,44 +19,66 @@ def get_files(path)
   Dir.entries(path).sort
 end
 
-def transform_contents_for_long_format(contents, option, path) # rubocop:disable all メソッドの行数が[22/20]となっていると警告が出るため。
-  filtered_contents = contents.reject { |content| content.start_with?('.') }
+def transform_files_for_long_format(files, option, path)
+  filtered_files = files.reject { |file| file.start_with?('.') }
 
   if option[:l]
-    new_contents = []
-    max_size_length = 0
-
-    filtered_contents.each do |content|
-      fs = File::Stat.new(File.join(path, content))
-      size_length = fs.size.to_s.length
-      max_size_length = size_length if size_length > max_size_length
-      octal_mode = fs.mode.to_s(8).rjust(6, '0')
-      mode = "#{FILE_MAP[octal_mode[0..2]]}#{PERMISSION_MAP[octal_mode[3]]}#{PERMISSION_MAP[octal_mode[4]]}#{PERMISSION_MAP[octal_mode[5]]}"
-      time = "#{fs.mtime.month.to_s.rjust(2)} #{fs.mtime.mday.to_s.rjust(2)} #{fs.mtime.hour.to_s.rjust(2, '0')}:#{fs.mtime.min.to_s.rjust(2, '0')}"
-      new_contents << [mode, fs.nlink.to_s.rjust(2), Etc.getpwuid(fs.uid).name, Etc.getgrgid(fs.gid).name, fs.size.to_s, time, content]
-    end
-
-    # 各行のファイルサイズを最大文字列長に合わせて整形
-    formatted_new_contents = []
-    new_contents.each do |content|
-      content[4] = content[4].rjust(max_size_length + 1)
-      formatted_new_contents << content.join(' ')
-    end
-    formatted_new_contents
+    get_file_detail_array(path, filtered_files)
   else
-    filtered_contents
+    filtered_files
   end
 end
 
-def show_as_grid(contents)
-  maximum_length = contents.max_by(&:length).length + SPACE_NUMBER # 本家lsコマンドに寄せたスペース幅に調整
-  height = contents.length.ceildiv(COLUMN_NUMBER)
+def show_as_grid(files)
+  maximum_length = files.max_by(&:length).length + SPACE_NUMBER # 本家lsコマンドに寄せたスペース幅に調整
+  height = files.length.ceildiv(COLUMN_NUMBER)
 
   (0...height).each do |h_num|
     COLUMN_NUMBER.times do |w_num|
-      contents_index = h_num + (height * w_num)
-      print contents[contents_index].ljust(maximum_length) if !contents[contents_index].nil?
+      files_index = h_num + (height * w_num)
+      print files[files_index].ljust(maximum_length) if !files[files_index].nil?
     end
     puts # ターミナル上で見栄えが悪いので改行。
   end
+end
+
+def get_file_type(file_lstat)
+  if file_lstat.file?
+    '-'
+  elsif file_lstat.symlink?
+    'l'
+  elsif file_lstat.blockdev?
+    'b'
+  elsif file_lstat.chardev?
+    'c'
+  elsif file_lstat.pipe?
+    'p'
+  elsif file_lstat.directory?
+    'd'
+  end
+end
+
+def get_file_detail_array(path, file_names)
+  file_detail_array = []
+  max_size_length = 0
+
+  file_names.each do |file_name|
+    outfile = File.join(path, file_name)
+    fs = File::Stat.new(outfile)
+    size_length = fs.size.to_s.length
+    max_size_length = size_length if size_length > max_size_length
+    file_type = get_file_type(File.lstat(outfile)) # File::Statは自動的にシンボリックリンクをたどっていき常にfalseを返すのでlstatを渡す。
+    octal_mode = fs.mode.to_s(8).rjust(6, '0')
+    mode = "#{PERMISSION_MAP[octal_mode[3]]}#{PERMISSION_MAP[octal_mode[4]]}#{PERMISSION_MAP[octal_mode[5]]}"
+    time = fs.mtime.strftime('%m %d %H:%M ')
+    file_detail_array << [file_type + mode, fs.nlink.to_s.rjust(2), Etc.getpwuid(fs.uid).name, Etc.getgrgid(fs.gid).name, fs.size.to_s, time, file_name]
+  end
+
+  # 最大文字列長に合わせて整形
+  formatted_file_detail_array = []
+  file_detail_array.each do |s|
+    s[4] = s[4].rjust(max_size_length + 1)
+    formatted_file_detail_array << s.join(' ')
+  end
+  formatted_file_detail_array
 end

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -39,16 +39,18 @@ def convert_with_l_option!(contents, path)
     size_length = fs.size.to_s.length
     max_size_length = size_length if size_length > max_size_length
     mode = convert_to_mode_symbol(fs.mode.to_s(8).rjust(6, '0'))
-    new_contents << "#{mode} #{Etc.getpwuid(fs.uid).name} #{Etc.getgrgid(fs.gid).name} #{fs.size} #{fs.mtime} #{content}"
+    time = time_formatter(fs.mtime)
+    # " 9 11 17:18"
+    new_contents << [mode, fs.nlink.to_s.rjust(2), Etc.getpwuid(fs.uid).name, Etc.getgrgid(fs.gid).name, fs.size.to_s, time, content]
   end
 
   # 各行のファイルサイズを最大文字列長に合わせて整形
-  new_contents.map! do |line|
-    parts = line.split
-    parts[3] = parts[3].rjust(max_size_length + 1)
-    parts.join(' ')
+  formatted_new_contents = []
+  new_contents.each do |content|
+    content[4] = content[4].rjust(max_size_length + 1)
+    formatted_new_contents << content.join(' ')
   end
-  new_contents
+  formatted_new_contents
 end
 
 def convert_to_mode_symbol(octal_mode)
@@ -73,4 +75,8 @@ def convert_to_mode_symbol(octal_mode)
     '0' => '---'
   }
   "#{file_map[octal_mode[0..2]]}#{permission_map[octal_mode[3]]}#{permission_map[octal_mode[4]]}#{permission_map[octal_mode[5]]}@"
+end
+
+def time_formatter(mtime)
+  "#{mtime.month.to_s.rjust(2)} #{mtime.mday.to_s.rjust(2)} #{mtime.hour.to_s.rjust(2, '0')}:#{mtime.min.to_s.rjust(2, '0')}"
 end

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -12,7 +12,7 @@ FILE_MAP = {
   '100' => '-',
   '120' => '|',
   '140' => 's'
-}
+}.freeze
 
 PERMISSION_MAP = {
   '7' => 'rwx',
@@ -23,13 +23,13 @@ PERMISSION_MAP = {
   '2' => '-w-',
   '1' => '--x',
   '0' => '---'
-}
+}.freeze
 
 def get_files(path)
   Dir.entries(path).sort
 end
 
-def transform_contents_for_long_format(contents, option, path)
+def transform_contents_for_long_format(contents, option, path) # rubocop:disable all メソッドの行数が[22/20]となっていると警告が出るため。
   filtered_contents = contents.reject { |content| content.start_with?('.') }
 
   if option[:l]

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -29,15 +29,36 @@ def get_files(path)
   Dir.entries(path).sort
 end
 
-def transform_by_option(contents, option, path)
+def transform_contents_for_long_format(contents, option, path)
   filtered_contents = contents.reject { |content| content.start_with?('.') }
 
-  return transform_by_l(filtered_contents, path) if option[:l]
+  if option[:l]
+    new_contents = []
+    max_size_length = 0
 
-  filtered_contents
+    filtered_contents.each do |content|
+      fs = File::Stat.new(File.join(path, content))
+      size_length = fs.size.to_s.length
+      max_size_length = size_length if size_length > max_size_length
+      octal_mode = fs.mode.to_s(8).rjust(6, '0')
+      mode = "#{FILE_MAP[octal_mode[0..2]]}#{PERMISSION_MAP[octal_mode[3]]}#{PERMISSION_MAP[octal_mode[4]]}#{PERMISSION_MAP[octal_mode[5]]}"
+      time = "#{fs.mtime.month.to_s.rjust(2)} #{fs.mtime.mday.to_s.rjust(2)} #{fs.mtime.hour.to_s.rjust(2, '0')}:#{fs.mtime.min.to_s.rjust(2, '0')}"
+      new_contents << [mode, fs.nlink.to_s.rjust(2), Etc.getpwuid(fs.uid).name, Etc.getgrgid(fs.gid).name, fs.size.to_s, time, content]
+    end
+
+    # 各行のファイルサイズを最大文字列長に合わせて整形
+    formatted_new_contents = []
+    new_contents.each do |content|
+      content[4] = content[4].rjust(max_size_length + 1)
+      formatted_new_contents << content.join(' ')
+    end
+    formatted_new_contents
+  else
+    filtered_contents
+  end
 end
 
-def show(contents)
+def show_as_grid(contents)
   maximum_length = contents.max_by(&:length).length + SPACE_NUMBER # 本家lsコマンドに寄せたスペース幅に調整
   height = contents.length.ceildiv(COLUMN_NUMBER)
 
@@ -48,27 +69,4 @@ def show(contents)
     end
     puts # ターミナル上で見栄えが悪いので改行。
   end
-end
-
-def transform_by_l(contents, path)
-  new_contents = []
-  max_size_length = 0
-
-  contents.each do |content|
-    fs = File::Stat.new("#{path}/#{content}")
-    size_length = fs.size.to_s.length
-    max_size_length = size_length if size_length > max_size_length
-    octal_mode = fs.mode.to_s(8).rjust(6, '0')
-    mode = "#{FILE_MAP[octal_mode[0..2]]}#{PERMISSION_MAP[octal_mode[3]]}#{PERMISSION_MAP[octal_mode[4]]}#{PERMISSION_MAP[octal_mode[5]]}"
-    time = "#{fs.mtime.month.to_s.rjust(2)} #{fs.mtime.mday.to_s.rjust(2)} #{fs.mtime.hour.to_s.rjust(2, '0')}:#{fs.mtime.min.to_s.rjust(2, '0')}"
-    new_contents << [mode, fs.nlink.to_s.rjust(2), Etc.getpwuid(fs.uid).name, Etc.getgrgid(fs.gid).name, fs.size.to_s, time, content]
-  end
-
-  # 各行のファイルサイズを最大文字列長に合わせて整形
-  formatted_new_contents = []
-  new_contents.each do |content|
-    content[4] = content[4].rjust(max_size_length + 1)
-    formatted_new_contents << content.join(' ')
-  end
-  formatted_new_contents
 end

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
+require 'etc'
+
 def get_files(path)
   Dir.entries(path).sort
 end
 
-def ls_with_options(contents, option)
-  if option.nil?
-    filtered_contents = contents.filter { |content| !content.start_with?('.') } # hidden fileをcontentsから除外する。
+def convert_with_option!(contents, option, path)
+  unless option[:a]
+    contents.reject! { |content| content.start_with?('.') } # hidden fileをcontentsから除外する。
   end
-  show_ls(filtered_contents)
+
+  return contents unless option[:l]
+
+  convert_with_l_option!(contents, path)
 end
 
 def show_ls(contents)
@@ -23,4 +28,49 @@ def show_ls(contents)
     end
     puts # ターミナル上で見栄えが悪いので改行。
   end
+end
+
+def convert_with_l_option!(contents, path)
+  new_contents = []
+  max_size_length = 0
+
+  contents.each do |content|
+    fs = File::Stat.new("#{path}/#{content}")
+    size_length = fs.size.to_s.length
+    max_size_length = size_length if size_length > max_size_length
+    mode = convert_to_mode_symbol(fs.mode.to_s(8).rjust(6, '0'))
+    new_contents << "#{mode} #{Etc.getpwuid(fs.uid).name} #{Etc.getgrgid(fs.gid).name} #{fs.size} #{fs.mtime} #{content}"
+  end
+
+  # 各行のファイルサイズを最大文字列長に合わせて整形
+  new_contents.map! do |line|
+    parts = line.split
+    parts[3] = parts[3].rjust(max_size_length + 1)
+    parts.join(' ')
+  end
+  new_contents
+end
+
+def convert_to_mode_symbol(octal_mode)
+  file_map = {
+    '010' => 'p',
+    '020' => 'c',
+    '040' => 'd',
+    '060' => 'b',
+    '100' => '-',
+    '120' => '|',
+    '140' => 's'
+  }
+
+  permission_map = {
+    '7' => 'rwx',
+    '6' => 'rw-',
+    '5' => 'r-x',
+    '4' => 'r--',
+    '3' => '-wx',
+    '2' => '-w-',
+    '1' => '--x',
+    '0' => '---'
+  }
+  "#{file_map[octal_mode[0..2]]}#{permission_map[octal_mode[3]]}#{permission_map[octal_mode[4]]}#{permission_map[octal_mode[5]]}@"
 end


### PR DESCRIPTION
## 使い方
```
ruby 04.ls/ls.rb -l [path]
```

## 実施内容
ls -l オプションと同じ表示が出来るオプションを追加。(下記に実行結果の各カラム情報を記載)
 - ファイルタイプとパーミション(一番左の1文字がファイルタイプを表します。 -:ファイル、d:ディレクトリ、l:シンボリックリンク など)
 - ハードリンク数
 - 所有者
 - 所有グループ
 - サイズ
 - 最終変更時刻
 - ファイル名

## PRポイント
- PRするレビュワーから見てレビューしやすいか。さらにレビューしやすくなるにはどのようにしたらいいのかアドバイスをお願いします🙏

## 実行結果

```
shunhamm@PM-PM9NWYCWGV ruby-practices % ruby 04.ls/ls.rb -l        
drwxr-xr-x@  4 shunhamm staff   128 10  5 11:28 01.fizzbuzz
drwxr-xr-x@  6 shunhamm staff   192 10  5 11:28 02.calendar
drwxr-xr-x@  4 shunhamm staff   128 10  5 11:28 03.bowling
drwxr-xr-x@  5 shunhamm staff   160 10  5 12:02 04.ls
drwxr-xr-x@  3 shunhamm staff    96  9 11 17:18 05.wc
drwxr-xr-x@  3 shunhamm staff    96  9 11 17:18 06.bowling_object
drwxr-xr-x@  3 shunhamm staff    96  9 11 17:18 07.ls_object
drwxr-xr-x@  3 shunhamm staff    96  9 11 17:18 98.rake
drwxr-xr-x@  3 shunhamm staff    96  9 11 17:18 99.wc_object
-rw-r--r--@  1 shunhamm staff  2648  9 11 17:18 README.md
-rw-r--r--@  1 shunhamm staff   202 10  5 11:28 practice.rb
shunhamm@PM-PM9NWYCWGV ruby-practices % ls -l
total 16
drwxr-xr-x@ 4 shunhamm  staff   128 10  5 11:28 01.fizzbuzz
drwxr-xr-x@ 6 shunhamm  staff   192 10  5 11:28 02.calendar
drwxr-xr-x@ 4 shunhamm  staff   128 10  5 11:28 03.bowling
drwxr-xr-x@ 5 shunhamm  staff   160 10  5 12:02 04.ls
drwxr-xr-x@ 3 shunhamm  staff    96  9 11 17:18 05.wc
drwxr-xr-x@ 3 shunhamm  staff    96  9 11 17:18 06.bowling_object
drwxr-xr-x@ 3 shunhamm  staff    96  9 11 17:18 07.ls_object
drwxr-xr-x@ 3 shunhamm  staff    96  9 11 17:18 98.rake
drwxr-xr-x@ 3 shunhamm  staff    96  9 11 17:18 99.wc_object
-rw-r--r--@ 1 shunhamm  staff  2648  9 11 17:18 README.md
-rw-r--r--@ 1 shunhamm  staff   202 10  5 11:28 practice.rb
```

rubocop
```
shunhamm@PM-PM9NWYCWGV ruby-practices % rubocop 04.ls 
Inspecting 2 files
..

2 files inspected, no offenses detected
```
