### PR TITLE
ls コマンドを作る5

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,11 +8,13 @@ def main
   option = {}
   opt = OptionParser.new
 
+  opt.on('-a') { |v| option[:a] = v }
+  opt.on('-r') { |v| option[:r] = v }
   opt.on('-l') { |v| option[:l] = v }
   opt.parse!(ARGV)
   path = ARGV[0].nil? ? '.' : ARGV[0]
   files = files(path)
-  transformed_files = transform_files_for_long_format(files, option, path)
+  transformed_files = transform_files_by_option(files, option, path)
 
   if option[:l]
     transformed_files.each { |files| puts files }

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -14,13 +14,13 @@ def main
   opt.parse!(ARGV)
   path = ARGV[0].nil? ? '.' : ARGV[0]
   files = files(path)
-  new_files = transform_by_option(files, option, path)
+  transformed_files = transform_by_option(files, option, path)
 
   if option[:l]
-    puts "total #{new_files[0]}"
-    new_files[1..].each { |files| puts files }
+    puts "total #{transformed_files[0]}"
+    transformed_files[1..].each { |files| puts files }
   else
-    show_as_grid(new_files)
+    show_as_grid(transformed_files)
   end
 end
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -14,12 +14,13 @@ def main
   opt.parse!(ARGV)
   path = ARGV[0].nil? ? '.' : ARGV[0]
   files = files(path)
-  transformed_files = transform_by_option(files, option, path)
+  new_files = transform_by_option(files, option, path)
 
   if option[:l]
-    transformed_files.each { |files| puts files }
+    puts "total #{new_files[0]}"
+    new_files[1..].each { |files| puts files }
   else
-    show_as_grid(transformed_files)
+    show_as_grid(new_files)
   end
 end
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -14,7 +14,7 @@ def main
   opt.parse!(ARGV)
   path = ARGV[0].nil? ? '.' : ARGV[0]
   files = files(path)
-  transformed_files = transform_files_by_option(files, option, path)
+  transformed_files = transform_by_option(files, option, path)
 
   if option[:l]
     transformed_files.each { |files| puts files }

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -19,7 +19,7 @@ def files(path)
   Dir.entries(path).sort
 end
 
-def transform_files_for_long_format(files, option, path)
+def transform_files_by_option(files, option, path)
   filtered_files = files.reject { |file| file.start_with?('.') }
 
   if option[:l]

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -21,18 +21,18 @@ end
 
 def transform_by_option(files, option, path)
   # aオプションのみの場合に引数を変更しないで返すためnew_filesに再定義している。
-  new_files = if option[:a]
-                files
-              else
-                files.reject { |file| file.start_with?('.') }
-              end
+  transformed_files = if option[:a]
+                        files
+                      else
+                        files.reject { |file| file.start_with?('.') }
+                      end
 
-  new_files = new_files.reverse if option[:r]
+  transformed_files = transformed_files.reverse if option[:r]
 
   if option[:l]
-    file_stats(new_files, path)
+    file_stats(transformed_files, path)
   else
-    new_files
+    transformed_files
   end
 end
 

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -68,21 +68,22 @@ end
 def file_stats(file_names, path)
   file_stats = []
   max_size_length = 0
+  total_file_blocks = 0
 
   file_names.each do |file_name|
     outfile = File.join(path, file_name)
     fs = File::Stat.new(outfile)
-    size_length = fs.size.to_s.length
-    max_size_length = size_length if size_length > max_size_length
+    max_size_length = fs.size.to_s.length if fs.size.to_s.length > max_size_length
     file_type = file_type(File.lstat(outfile)) # File::Statは自動的にシンボリックリンクをたどっていき常にfalseを返すのでlstatを渡す。
     octal_mode = fs.mode.to_s(8).rjust(6, '0')
     mode = "#{PERMISSION_MAP[octal_mode[3]]}#{PERMISSION_MAP[octal_mode[4]]}#{PERMISSION_MAP[octal_mode[5]]}"
     time = fs.mtime.strftime('%m %d %H:%M ')
     file_stats << [file_type + mode, fs.nlink.to_s.rjust(2), Etc.getpwuid(fs.uid).name, Etc.getgrgid(fs.gid).name, fs.size.to_s, time, file_name]
+    total_file_blocks += fs.blocks
   end
 
   # 最大文字列長に合わせて整形
-  formatted_file_stats = []
+  formatted_file_stats = [total_file_blocks]
   file_stats.each do |s|
     s[4] = s[4].rjust(max_size_length + 1)
     formatted_file_stats << s.join(' ')

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -19,7 +19,7 @@ def files(path)
   Dir.entries(path).sort
 end
 
-def transform_files_by_option(files, option, path)
+def transform_by_option(files, option, path)
   filtered_files = files.reject { |file| file.start_with?('.') }
 
   if option[:l]

--- a/04.ls/ls_methods.rb
+++ b/04.ls/ls_methods.rb
@@ -20,12 +20,19 @@ def files(path)
 end
 
 def transform_by_option(files, option, path)
-  filtered_files = files.reject { |file| file.start_with?('.') }
+  # aオプションのみの場合に引数を変更しないで返すためnew_filesに再定義している。
+  new_files = if option[:a]
+                files
+              else
+                files.reject { |file| file.start_with?('.') }
+              end
+
+  new_files = new_files.reverse if option[:r]
 
   if option[:l]
-    file_stats(path, filtered_files)
+    file_stats(new_files, path)
   else
-    filtered_files
+    new_files
   end
 end
 
@@ -58,7 +65,7 @@ def file_type(file_lstat)
   end
 end
 
-def file_stats(path, file_names)
+def file_stats(file_names, path)
   file_stats = []
   max_size_length = 0
 


### PR DESCRIPTION
## 使い方
```
ruby 04.ls/ls.rb [-Options] [path]
```

## 実施内容
- 1 - 4で実装したlsコマンドとそのオプション(a, r, l)を組み合わせて使えるようにした。
- 命名を変更した(transform_by_option: optionによって表示するロジックに渡すためのfilesの組成を変えるという意味)

## PRポイント
- 命名がおかしくないか。
- ls_methods:23 にコメントを追記したので意図を伝えるための必要性のあるコメントになっているのか。
以上と他に何かあればコメントをお願いいたします！（過去のPRでいただいたコメントはもう一度見返したので抜けがあればすみませんが再指摘お願いします。）
## 実行結果

### `-a`
<img width="458" alt="スクリーンショット 2023-10-23 17 58 01" src="https://github.com/shunhamm/ruby-practices/assets/52060354/3f762831-f0f3-4a53-b967-7a612dbd0c92">

### '-l'
<img width="555" alt="スクリーンショット 2023-10-23 17 58 15" src="https://github.com/shunhamm/ruby-practices/assets/52060354/1f1abeba-578b-471c-8a8c-4f7c808fc7a1">

### `-r`
<img width="479" alt="スクリーンショット 2023-10-23 17 58 24" src="https://github.com/shunhamm/ruby-practices/assets/52060354/8dc76bf5-0e68-4c04-ad8b-f090e1171079">

### `-al`
<img width="510" alt="スクリーンショット 2023-10-23 17 58 33" src="https://github.com/shunhamm/ruby-practices/assets/52060354/4c50ef18-7ddf-4d3c-9695-5b63b37165e0">

### `alr`
<img width="507" alt="スクリーンショット 2023-10-23 17 58 52" src="https://github.com/shunhamm/ruby-practices/assets/52060354/f70018bf-0bf2-4acb-bc1b-6874eb6afe08">

### `-lra`
<img width="512" alt="スクリーンショット 2023-10-23 17 59 07" src="https://github.com/shunhamm/ruby-practices/assets/52060354/da852c47-a741-4389-b288-a11043f7b01c">

### `-ar`
<img width="491" alt="スクリーンショット 2023-10-23 17 59 22" src="https://github.com/shunhamm/ruby-practices/assets/52060354/9aa26681-f9fb-4d4b-b54a-15c92e6270f1">

### `rubocop`
<img width="457" alt="スクリーンショット 2023-10-23 17 59 42" src="https://github.com/shunhamm/ruby-practices/assets/52060354/0735d9e3-4432-46ad-a8a8-77424680af1f">
